### PR TITLE
relation does not exist (camel case)

### DIFF
--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -264,7 +264,7 @@ var Schema = function (db, options) {
       't.tablename    AS name, ' +
       'd.description  AS comment ' +
       'FROM pg_tables t ' +
-      "LEFT JOIN pg_attribute a ON a.attrelid=t.tablename::regclass AND a.attname='tableoid' " +
+      "LEFT JOIN pg_attribute a ON a.attrelid=quote_ident(t.tablename)::regclass AND a.attname='tableoid' " +
       'LEFT JOIN pg_description d ON d.objoid = a.attrelid AND d.objsubid = 0' +
       'WHERE schemaname = $1',
       ['public'],
@@ -301,7 +301,7 @@ var Schema = function (db, options) {
     'LEFT JOIN pg_attrdef f ON f.adrelid = a.attrelid  AND f.adnum = a.attnum ' +
     'WHERE a.attnum > 0 ' +
     'AND NOT a.attisdropped ' +
-    'AND a.attrelid = $1::regclass ' +
+    'AND a.attrelid = quote_ident($1)::regclass ' +
     'ORDER BY a.attnum',
       [table],
       function (err, result) {


### PR DESCRIPTION
The script doesn't work with camel case table names. When a table name is "myTable", I'm getting an error: relation "mytable" does not exist. That's because table names are not quoted in the SQL queries when used with "regclass".