### PR TITLE
Fixed a problem that resulted in broken SQL if table or column comments contained single quotes (').

### DIFF
--- a/lib/Delta.js
+++ b/lib/Delta.js
@@ -74,6 +74,29 @@ var Delta = function (schema1, schema2, options) {
   }
 
   /**
+   * Generate right format to use a value in sql query
+   * @private
+   * @function
+   * @param {*} value Value to transform
+   * @returns {string}
+   */  
+  var _formatSqlValue = function (value) {
+    if (value == null || value==='' || (value instanceof Array && value.length == 0)) {
+      return 'null'
+    }
+    if (value instanceof Date) {
+      return "'" + (new Date(value)).toISOString() + "'"
+    }
+    if (value instanceof Object) {
+      return "'" + JSON.stringify(value) + "'"
+    }
+    if (typeof value === 'string') {
+      value = value.replace(/'/g, "''")
+    }
+    return "'" + value + "'"
+  }
+
+  /**
    * Compare each table of both schema and retrieve the sql code to execute
    * @private
    * @function
@@ -137,13 +160,13 @@ var Delta = function (schema1, schema2, options) {
           // / check column comment
           if ((!_exists && _columns1[c1].comment) || _columns1[c1].comment !== _columns2[c2].comment) {
             _sqlColumns.push('COMMENT ON COLUMN ' + _tables1[t] + '.' + _columns1[c1].name + ' IS ' +
-              (_columns1[c1].comment ? "'" + _columns1[c1].comment + "'" : 'NULL') + ';')
+              (_columns1[c1].comment ? _formatSqlValue(_columns1[c1].comment) : 'NULL') + ';')
           }
         }
         // / if comments on the table are different, modify it
         if (schema1.tables[_tables1[t]].comment !== schema2.tables[_tables1[t]].comment) {
           _sqlColumns.push('COMMENT ON TABLE ' + _tables1[t] + ' IS ' +
-            (schema1.tables[_tables1[t]].comment ? "'" + schema1.tables[_tables1[t]].comment + "'" : 'NULL') + ';')
+            (schema1.tables[_tables1[t]].comment ? _formatSqlValue(schema1.tables[_tables1[t]].comment) : 'NULL') + ';')
         }
         // / if option mode is full, check if column from table 2 missing from column table 1 -> drop
         if (options.mode === 'full') {
@@ -177,7 +200,7 @@ var Delta = function (schema1, schema2, options) {
           // / check if adding column comments
           if (_columns1[c].comment) {
             _sqlColumnComment.push('COMMENT ON COLUMN ' + _tables1[t] + '.' + _columns1[c].name + ' IS ' +
-              "'" + _columns1[c].comment + "'")
+              _formatSqlValue(_columns1[c].comment))
           }
         }
         _sqlTable.push(_sqlColumns.join(','), ');')
@@ -185,7 +208,7 @@ var Delta = function (schema1, schema2, options) {
         _sqlTable.push('ALTER TABLE ' + _tables1[t] + ' OWNER TO ' + options.owner + ';')
         // / add comment if present
         if (schema1.tables[_tables1[t]].comment) {
-          _sqlTable.push('COMMENT ON TABLE ' + _tables1[t] + " IS '" + schema1.tables[_tables1[t]].comment + "';")
+          _sqlTable.push('COMMENT ON TABLE ' + _tables1[t] + " IS " + _formatSqlValue(schema1.tables[_tables1[t]].comment) + ";")
         }
         // / add comment on columns if present
         if (_sqlColumnComment.length > 0) {
@@ -747,29 +770,6 @@ var Delta = function (schema1, schema2, options) {
     var _tabledata1 = schema1.tabledata
     var _tabledata2 = schema2.tabledata
     var _sqls = []
-    
-    /**
-     * Generate right format to use a value in sql query
-     * @private
-     * @function
-     * @param {*} value Value to transform
-     * @returns {string}
-     */  
-    var _formatSqlValue = function (value) {
-      if (value == null || value==='' || (value instanceof Array && value.length == 0)) {
-        return 'null'
-      }
-      if (value instanceof Date) {
-        return "'" + (new Date(value)).toISOString() + "'"
-      }
-      if (value instanceof Object) {
-        return "'" + JSON.stringify(value) + "'"
-      }
-      if (typeof value === 'string') {
-        value = value.replace(/'/g, "''")
-      }
-      return "'" + value + "'"
-    }
     
     /**
      * Generate an insert query from a given row


### PR DESCRIPTION
Hoisted _formatSqlValue() to a higher level so that it would be visible to __compareTables() and replaced string concatenation with _formatSqlValue().